### PR TITLE
Fix typo with init.py's __all__

### DIFF
--- a/ipld/__init__.py
+++ b/ipld/__init__.py
@@ -1,5 +1,5 @@
 from ipld.ipld import LINK_TAG, LINK_SYMBOL, marshal, multihash, unmarshal
 
-__all_ = ['LINK_TAG', 'LINK_SYMBOL', 'marshal', 'multihash', 'unmarshal']
+__all__ = ['LINK_TAG', 'LINK_SYMBOL', 'marshal', 'multihash', 'unmarshal']
 
 __version__ = '0.0.1'


### PR DESCRIPTION
Assuming we want to allow `import *`s :).
